### PR TITLE
stripping of input text

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ def index():
 @app.route("/", methods=["POST"])
 def my_form_post():
     text = request.form["text"]
+    text.strip() #remove leading and trailing whitespaces 
     # TODO: Add error handling
     if text.startswith("https://pastebin.com/"):
         build = pobapi.from_url(text)


### PR DESCRIPTION
this removes the leading and trailing whitespaces.
If you copied some leading or trailing whitespaces from the forum (which happens to me way to often), the app will throw an 500 error.
This changes should (i couldn't test it since i don't have an python setup right now) at least trim it back, so it can't happen by accident.